### PR TITLE
fix(MultiSelectProvider.tsx): double addition on mobile

### DIFF
--- a/packages/camp/src/MultiSelect/MultiSelectProvider.tsx
+++ b/packages/camp/src/MultiSelect/MultiSelectProvider.tsx
@@ -163,15 +163,13 @@ export const MultiSelectProvider = ({
   } = useMultipleSelection<(typeof items)[0]>({
     selectedItems,
     onSelectedItemsChange: ({ selectedItems }) => {
-      onChange(
-        [
-          ...new Set(
-            selectedItems
-              ?.filter((item) => !isItemDisabled(item))
-              .map(itemToValue),
-          ),
-        ] ?? [],
-      )
+      onChange([
+        ...new Set(
+          selectedItems
+            ?.filter((item) => !isItemDisabled(item))
+            .map(itemToValue),
+        ),
+      ])
     },
     itemToString: itemToLabelString,
     stateReducer: (_state, { changes, type }) => {

--- a/packages/camp/src/MultiSelect/MultiSelectProvider.tsx
+++ b/packages/camp/src/MultiSelect/MultiSelectProvider.tsx
@@ -164,9 +164,13 @@ export const MultiSelectProvider = ({
     selectedItems,
     onSelectedItemsChange: ({ selectedItems }) => {
       onChange(
-        selectedItems
-          ?.filter((item) => !isItemDisabled(item))
-          .map(itemToValue) ?? [],
+        [
+          ...new Set(
+            selectedItems
+              ?.filter((item) => !isItemDisabled(item))
+              .map(itemToValue),
+          ),
+        ] ?? [],
       )
     },
     itemToString: itemToLabelString,


### PR DESCRIPTION
## Problem
This issue was first identified on ActiveSG where programme filters would be added twice when users performed the action on mobile. This issue does not exist outside mobile mode. 

Refer to the following recording of the issue:

https://github.com/user-attachments/assets/c2342717-9f22-4a3e-9a3e-20efe3e227f7

## Investigation
The root cause of the issue is still unclear. 

@dextertanyj identified that `itemHandleClick` function in `downshift` is only called once, eliminating the hypothesis that there was a bug in the package that led to the event being fired twice. 

@dextertanyj further identified that on mobile, two events `onClick` and `onMouseMove` are fired at the same time (thus causing two state transitions). The current hypothesis is that this bug arises due to the way React handles both these transitions happening at (almost) the same time.

This issue has been raised before, the conclusion is similar to ours: https://github.com/downshift-js/downshift/issues/1534

## Solution

Since the issue might be due to the internal implementation of React, we decided to instead just make the component idempotent. Thus, in `onSelectedItemsChange`, I use a set to remove duplicates.

