### PR TITLE
Chore/add field styles for number input

### DIFF
--- a/packages/camp/src/NumberInput/NumberInput.stories.tsx
+++ b/packages/camp/src/NumberInput/NumberInput.stories.tsx
@@ -100,3 +100,9 @@ export const FormInput: StoryFn<NumberInputProps> = (args) => {
     </FormControl>
   )
 }
+
+export const InputStyles = Template.bind({})
+InputStyles.args = {
+  placeholder: 'Pass in input styles',
+  inputStyles: { bgColor: 'gray.100' },
+}

--- a/packages/camp/src/NumberInput/NumberInput.tsx
+++ b/packages/camp/src/NumberInput/NumberInput.tsx
@@ -1,17 +1,18 @@
-import type { Ref } from 'react'
-import { useRef } from 'react'
 import {
   Box,
   chakra,
-  ComponentWithAs as _,
+  NumberInputProps as ChakraNumberInputProps,
   Divider,
   forwardRef,
-  NumberInputProps as ChakraNumberInputProps,
+  mergeThemeOverride,
+  SystemStyleObject,
   useFormControlProps,
   useMergeRefs,
   useMultiStyleConfig,
   useNumberInput,
 } from '@chakra-ui/react'
+import type { Ref } from 'react'
+import { useMemo, useRef } from 'react'
 
 import { IconButton } from '~/IconButton'
 import { BxMinus, BxPlus } from '~/icons'
@@ -29,6 +30,8 @@ export interface NumberInputProps extends ChakraNumberInputProps {
    * Whether to show the increment and decrement steppers. Defaults to true.
    */
   showSteppers?: boolean
+
+  inputStyles?: SystemStyleObject
 }
 
 export const NumberInput = forwardRef<NumberInputProps, 'input'>(
@@ -38,6 +41,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
       clampValueOnBlur = false,
       isSuccess,
       isPrefilled,
+      inputStyles,
       ...props
     },
     ref,
@@ -47,6 +51,11 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
       isSuccess,
       isPrefilled,
     })
+
+    const mergedInputStyles = useMemo(
+      () => mergeThemeOverride(styles.field, inputStyles),
+      [inputStyles, styles.field],
+    )
 
     const stepperWrapperRef = useRef<HTMLDivElement | null>(null)
 
@@ -90,6 +99,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
           // is this input.
           ref={inputRef}
           __css={styles.field}
+          sx={mergedInputStyles}
         />
         {showSteppers && (
           <Box __css={styles.stepperWrapper} ref={stepperWrapperRef}>

--- a/packages/camp/src/NumberInput/NumberInput.tsx
+++ b/packages/camp/src/NumberInput/NumberInput.tsx
@@ -1,18 +1,18 @@
+import type { Ref } from 'react'
+import { useMemo, useRef } from 'react'
 import {
   Box,
   chakra,
-  NumberInputProps as ChakraNumberInputProps,
   Divider,
   forwardRef,
   mergeThemeOverride,
+  NumberInputProps as ChakraNumberInputProps,
   SystemStyleObject,
   useFormControlProps,
   useMergeRefs,
   useMultiStyleConfig,
   useNumberInput,
 } from '@chakra-ui/react'
-import type { Ref } from 'react'
-import { useMemo, useRef } from 'react'
 
 import { IconButton } from '~/IconButton'
 import { BxMinus, BxPlus } from '~/icons'
@@ -31,6 +31,9 @@ export interface NumberInputProps extends ChakraNumberInputProps {
    */
   showSteppers?: boolean
 
+  /**
+   * Merge styles for inner input field
+   */
   inputStyles?: SystemStyleObject
 }
 

--- a/packages/camp/src/NumberInput/NumberInput.tsx
+++ b/packages/camp/src/NumberInput/NumberInput.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import {
   Box,
   chakra,
   Divider,
   forwardRef,
-  mergeThemeOverride,
   NumberInputProps as ChakraNumberInputProps,
   SystemStyleObject,
   useFormControlProps,
@@ -55,11 +54,6 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
       isPrefilled,
     })
 
-    const mergedInputStyles = useMemo(
-      () => mergeThemeOverride(styles.field, inputStyles),
-      [inputStyles, styles.field],
-    )
-
     const stepperWrapperRef = useRef<HTMLDivElement | null>(null)
 
     /**
@@ -102,7 +96,7 @@ export const NumberInput = forwardRef<NumberInputProps, 'input'>(
           // is this input.
           ref={inputRef}
           __css={styles.field}
-          sx={mergedInputStyles}
+          sx={inputStyles}
         />
         {showSteppers && (
           <Box __css={styles.stepperWrapper} ref={stepperWrapperRef}>


### PR DESCRIPTION
Currently NumberInput does not allow for overriding of inner input styles. Armoury needs to override the padding so that the number does not cut off
<img width="420" alt="image" src="https://github.com/user-attachments/assets/ed09f29b-d6f9-4ded-afb5-a3a26c1341e3" />

Solution
Allow merging of styles for inner input component in NumberInput 

Local test
<img width="1078" alt="Screenshot 2024-12-16 at 5 43 31 PM" src="https://github.com/user-attachments/assets/78b40ca4-71ce-4e9b-af0b-63b28ed25325" />

