### PR TITLE
fix: themeable input

### DIFF
--- a/packages/camp/src/Input/Input.stories.tsx
+++ b/packages/camp/src/Input/Input.stories.tsx
@@ -21,13 +21,11 @@ Prefilled.args = {
   defaultValue: 'Prefilled field',
   isPrefilled: true,
 }
-
 export const Error = Template.bind({})
 Error.args = {
   isInvalid: true,
   defaultValue: 'Field error',
 }
-
 export const Success = Template.bind({})
 Success.args = {
   isSuccess: true,
@@ -37,6 +35,11 @@ export const Disabled = Template.bind({})
 Disabled.args = {
   defaultValue: 'Some text',
   isDisabled: true,
+}
+export const Themeable = Template.bind({})
+Themeable.args = {
+  defaultValue: 'Some text',
+  width: '300px',
 }
 
 export const Sizes = () => (

--- a/packages/camp/src/Input/Input.tsx
+++ b/packages/camp/src/Input/Input.tsx
@@ -30,13 +30,18 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
   // Omit extra props so they will not be passed into the DOM and trigger
   // React warnings.
   const inputProps = omit(props, ['isSuccess', 'isPrefilled'])
+  const dataAttributes = {
+    'data-is-success': props.isSuccess || undefined,
+    'data-is-prefilled': props.isPrefilled || undefined,
+  }
 
   // Return normal input component if not success state.
   if (!props.isSuccess) {
     return (
       <ChakraInput
         ref={ref}
-        sx={merge({}, inputStyles.field, props.sx)}
+        __css={inputStyles.field}
+        {...dataAttributes}
         {...inputProps}
       />
     )
@@ -48,7 +53,8 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
     <InputGroup>
       <ChakraInput
         ref={ref}
-        sx={merge({}, inputStyles.field, props.sx)}
+        __css={inputStyles.field}
+        {...dataAttributes}
         {...inputProps}
       />
       <InputRightElement sx={inputStyles.success}>

--- a/packages/camp/src/Input/Input.tsx
+++ b/packages/camp/src/Input/Input.tsx
@@ -8,6 +8,7 @@ import {
   InputRightElement,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
+import { dataAttr } from '@chakra-ui/utils'
 import omit from 'lodash/omit'
 
 import { BxsCheckCircle } from '~/icons/BxsCheckCircle'
@@ -30,8 +31,8 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
   // React warnings.
   const inputProps = omit(props, ['isSuccess', 'isPrefilled'])
   const dataAttributes = {
-    'data-success': props.isSuccess || undefined,
-    'data-prefilled': props.isPrefilled || undefined,
+    'data-success': dataAttr(props.isSuccess),
+    'data-prefilled': dataAttr(props.isPrefilled),
   }
 
   // Return normal input component if not success state.

--- a/packages/camp/src/Input/Input.tsx
+++ b/packages/camp/src/Input/Input.tsx
@@ -8,7 +8,6 @@ import {
   InputRightElement,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
-import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 
 import { BxsCheckCircle } from '~/icons/BxsCheckCircle'

--- a/packages/camp/src/Input/Input.tsx
+++ b/packages/camp/src/Input/Input.tsx
@@ -30,8 +30,8 @@ export const Input = forwardRef<InputProps, 'input'>((props, ref) => {
   // React warnings.
   const inputProps = omit(props, ['isSuccess', 'isPrefilled'])
   const dataAttributes = {
-    'data-is-success': props.isSuccess || undefined,
-    'data-is-prefilled': props.isPrefilled || undefined,
+    'data-success': props.isSuccess || undefined,
+    'data-prefilled': props.isPrefilled || undefined,
   }
 
   // Return normal input component if not success state.

--- a/packages/camp/src/theme/components/Input.ts
+++ b/packages/camp/src/theme/components/Input.ts
@@ -11,12 +11,12 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const outlineVariant = definePartsStyle((props) => {
   const {
-    isSuccess,
-    isPrefilled,
     theme,
     focusBorderColor: fc = 'utility.focus-default',
     errorBorderColor: ec = 'interaction.critical.default',
   } = props
+  const isPrefilled = props['data-is-prefilled']
+  const isSuccess = props['data-is-success']
 
   return {
     addon: {

--- a/packages/camp/src/theme/components/Input.ts
+++ b/packages/camp/src/theme/components/Input.ts
@@ -15,8 +15,10 @@ const outlineVariant = definePartsStyle((props) => {
     focusBorderColor: fc = 'utility.focus-default',
     errorBorderColor: ec = 'interaction.critical.default',
   } = props
-  const isPrefilled = props['data-is-prefilled']
-  const isSuccess = props['data-is-success']
+
+  // The variant is used by both input as well as other components.
+  const isPrefilled = props.isPrefilled ?? props['data-is-prefilled']
+  const isSuccess = props.isSuccess ?? props['data-is-success']
 
   return {
     addon: {

--- a/packages/camp/src/theme/components/Input.ts
+++ b/packages/camp/src/theme/components/Input.ts
@@ -17,8 +17,8 @@ const outlineVariant = definePartsStyle((props) => {
   } = props
 
   // The variant is used by both input as well as other components.
-  const isPrefilled = props.isPrefilled ?? props['data-prefilled']
-  const isSuccess = props.isSuccess ?? props['data-success']
+  const isPrefilled = props.isPrefilled ?? props['data-prefilled'] !== undefined
+  const isSuccess = props.isSuccess ?? props['data-success'] !== undefined
 
   return {
     addon: {

--- a/packages/camp/src/theme/components/Input.ts
+++ b/packages/camp/src/theme/components/Input.ts
@@ -17,8 +17,8 @@ const outlineVariant = definePartsStyle((props) => {
   } = props
 
   // The variant is used by both input as well as other components.
-  const isPrefilled = props.isPrefilled ?? props['data-is-prefilled']
-  const isSuccess = props.isSuccess ?? props['data-is-success']
+  const isPrefilled = props.isPrefilled ?? props['data-prefilled']
+  const isSuccess = props.isSuccess ?? props['data-success']
 
   return {
     addon: {


### PR DESCRIPTION
Properly fixes the passing of `isSuccess` and `isPrefilled` values into the `Input` component.

The initial fix outlined in #754 results in a significant regression as the `sx` prop overwrites all other styling applied via props.

This fix passes the above two values into the actual Chakra `Input` component as data attributes allowing them to safely exist in the DOM element.