### PR TITLE
fix: prop drill onYearChange and onMonthChange

### DIFF
--- a/packages/camp/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/camp/src/DatePicker/DatePicker.stories.tsx
@@ -110,6 +110,49 @@ MobileCustomInput.args = {
 }
 MobileCustomInput.parameters = getMobileViewParameters()
 
+const MonthYearChangeTemplate: StoryFn<DatePickerProps> = () => {
+  const [currentMonth, setCurrentMonth] = useState<number>()
+  const [currentYear, setCurrentYear] = useState<number>()
+
+  return (
+    <Stack spacing={4}>
+      <FormControl>
+        <FormLabel>Date Picker with Month/Year Change Tracking</FormLabel>
+        <DatePicker
+          onMonthChange={setCurrentMonth}
+          onYearChange={setCurrentYear}
+        />
+      </FormControl>
+      <Stack>
+        <FormControl>
+          <FormLabel>Current Month</FormLabel>
+          <Button variant="outline" pointerEvents="none">
+            {currentMonth !== undefined
+              ? currentMonth + 1
+              : 'No month selected'}
+          </Button>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Current Year</FormLabel>
+          <Button variant="outline" pointerEvents="none">
+            {currentYear !== undefined ? currentYear : 'No year selected'}
+          </Button>
+        </FormControl>
+      </Stack>
+    </Stack>
+  )
+}
+
+export const MonthYearChangeTracking = MonthYearChangeTemplate.bind({})
+MonthYearChangeTracking.parameters = {
+  docs: {
+    description: {
+      story:
+        'This example shows how to use `onMonthChange` and `onYearChange` callbacks to track calendar navigation.',
+    },
+  },
+}
+
 const ControlledTemplate: StoryFn<DatePickerProps> = (args) => {
   const [datestate, setDatestate] = useState<DatePickerProps['value']>()
 

--- a/packages/camp/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/camp/src/DatePicker/DatePicker.stories.tsx
@@ -110,45 +110,16 @@ MobileCustomInput.args = {
 }
 MobileCustomInput.parameters = getMobileViewParameters()
 
-const MonthYearChangeTemplate: StoryFn<DatePickerProps> = () => {
-  const [currentMonth, setCurrentMonth] = useState<number>()
-  const [currentYear, setCurrentYear] = useState<number>()
-
-  return (
-    <Stack spacing={4}>
-      <FormControl>
-        <FormLabel>Date Picker with Month/Year Change Tracking</FormLabel>
-        <DatePicker
-          onMonthChange={setCurrentMonth}
-          onYearChange={setCurrentYear}
-        />
-      </FormControl>
-      <Stack>
-        <FormControl>
-          <FormLabel>Current Month</FormLabel>
-          <Button variant="outline" pointerEvents="none">
-            {currentMonth !== undefined
-              ? currentMonth + 1
-              : 'No month selected'}
-          </Button>
-        </FormControl>
-        <FormControl>
-          <FormLabel>Current Year</FormLabel>
-          <Button variant="outline" pointerEvents="none">
-            {currentYear !== undefined ? currentYear : 'No year selected'}
-          </Button>
-        </FormControl>
-      </Stack>
-    </Stack>
-  )
+export const WithMonthYearChangeCallbacks = Template.bind({})
+WithMonthYearChangeCallbacks.args = {
+  onMonthChange: (month) => alert(`Month changed to: ${month + 1}`),
+  onYearChange: (year) => alert(`Year changed to: ${year}`),
 }
-
-export const MonthYearChangeTracking = MonthYearChangeTemplate.bind({})
-MonthYearChangeTracking.parameters = {
+WithMonthYearChangeCallbacks.parameters = {
   docs: {
     description: {
       story:
-        'This example shows how to use `onMonthChange` and `onYearChange` callbacks to track calendar navigation.',
+        'This example demonstrates `onMonthChange` and `onYearChange` callbacks. Alerts will appear when navigating the calendar.',
     },
   },
 }

--- a/packages/camp/src/DatePicker/utils/pickCalendarProps.ts
+++ b/packages/camp/src/DatePicker/utils/pickCalendarProps.ts
@@ -12,5 +12,7 @@ export const pickCalendarProps = (props: DatePickerProps) => {
     'showOutsideDays',
     'showTodayButton',
     'shouldSetDateOnTodayButtonClick',
+    'onMonthChange',
+    'onYearChange',
   )
 }

--- a/packages/camp/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/camp/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -76,6 +76,49 @@ SizeXs.args = {
   size: 'xs',
 }
 
+const MonthYearChangeTemplate: StoryFn<DateRangePickerProps> = () => {
+  const [currentMonth, setCurrentMonth] = useState<number>()
+  const [currentYear, setCurrentYear] = useState<number>()
+
+  return (
+    <Stack spacing={4}>
+      <FormControl>
+        <FormLabel>Date Range Picker with Month/Year Change Tracking</FormLabel>
+        <DateRangePicker
+          onMonthChange={setCurrentMonth}
+          onYearChange={setCurrentYear}
+        />
+      </FormControl>
+      <Stack>
+        <FormControl>
+          <FormLabel>Current Month</FormLabel>
+          <Button variant="outline" pointerEvents="none">
+            {currentMonth !== undefined
+              ? currentMonth + 1
+              : 'No month selected'}
+          </Button>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Current Year</FormLabel>
+          <Button variant="outline" pointerEvents="none">
+            {currentYear !== undefined ? currentYear : 'No year selected'}
+          </Button>
+        </FormControl>
+      </Stack>
+    </Stack>
+  )
+}
+
+export const MonthYearChangeTracking = MonthYearChangeTemplate.bind({})
+MonthYearChangeTracking.parameters = {
+  docs: {
+    description: {
+      story:
+        'This example shows how to use `onMonthChange` and `onYearChange` callbacks to track calendar navigation.',
+    },
+  },
+}
+
 const ControlledTemplate: StoryFn<DateRangePickerProps> = (args) => {
   const [datestate, setDatestate] = useState<DateRangeValue>([null, null])
 

--- a/packages/camp/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/camp/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -76,45 +76,16 @@ SizeXs.args = {
   size: 'xs',
 }
 
-const MonthYearChangeTemplate: StoryFn<DateRangePickerProps> = () => {
-  const [currentMonth, setCurrentMonth] = useState<number>()
-  const [currentYear, setCurrentYear] = useState<number>()
-
-  return (
-    <Stack spacing={4}>
-      <FormControl>
-        <FormLabel>Date Range Picker with Month/Year Change Tracking</FormLabel>
-        <DateRangePicker
-          onMonthChange={setCurrentMonth}
-          onYearChange={setCurrentYear}
-        />
-      </FormControl>
-      <Stack>
-        <FormControl>
-          <FormLabel>Current Month</FormLabel>
-          <Button variant="outline" pointerEvents="none">
-            {currentMonth !== undefined
-              ? currentMonth + 1
-              : 'No month selected'}
-          </Button>
-        </FormControl>
-        <FormControl>
-          <FormLabel>Current Year</FormLabel>
-          <Button variant="outline" pointerEvents="none">
-            {currentYear !== undefined ? currentYear : 'No year selected'}
-          </Button>
-        </FormControl>
-      </Stack>
-    </Stack>
-  )
+export const WithMonthYearChangeCallbacks = Template.bind({})
+WithMonthYearChangeCallbacks.args = {
+  onMonthChange: (month) => alert(`Month changed to: ${month + 1}`),
+  onYearChange: (year) => alert(`Year changed to: ${year}`),
 }
-
-export const MonthYearChangeTracking = MonthYearChangeTemplate.bind({})
-MonthYearChangeTracking.parameters = {
+WithMonthYearChangeCallbacks.parameters = {
   docs: {
     description: {
       story:
-        'This example shows how to use `onMonthChange` and `onYearChange` callbacks to track calendar navigation.',
+        'Demonstrates onMonthChange and onYearChange callbacks with alerts when navigating.',
     },
   },
 }

--- a/packages/camp/src/DateRangePicker/DateRangePickerContext.tsx
+++ b/packages/camp/src/DateRangePicker/DateRangePickerContext.tsx
@@ -25,11 +25,10 @@ import {
 import { format, isValid, parse } from 'date-fns'
 
 import { DateRangeValue, RangeCalendarProps } from '~/Calendar'
-import { pickCalendarProps } from '~/DatePicker/utils'
 import { useIsMobile } from '~/hooks/useIsMobile'
 
 import { DateRangePickerProps } from './DateRangePicker'
-import { validateDateRange } from './utils'
+import { pickRangeCalendarProps, validateDateRange } from './utils'
 
 interface DateRangePickerContextReturn {
   isMobile: boolean
@@ -63,6 +62,8 @@ interface DateRangePickerContextReturn {
     | 'defaultFocusedDate'
     | 'showTodayButton'
     | 'shouldSetDateOnTodayButtonClick'
+    | 'onMonthChange'
+    | 'onYearChange'
   >
   inputPattern?: string
 }
@@ -121,7 +122,7 @@ const useProvideDateRangePicker = ({
   const startInputRef = useRef<HTMLInputElement>(null)
   const endInputRef = useRef<HTMLInputElement>(null)
 
-  const calendarProps = pickCalendarProps(props)
+  const calendarProps = pickRangeCalendarProps(props)
 
   const isMobile = useIsMobile({ ssr })
 

--- a/packages/camp/src/DateRangePicker/utils.ts
+++ b/packages/camp/src/DateRangePicker/utils.ts
@@ -1,6 +1,9 @@
 import { isValid } from 'date-fns'
+import pick from 'lodash/pick'
 
 import type { DateRangeValue } from '~/Calendar'
+
+import { DateRangePickerProps } from './DateRangePicker'
 
 export const validateDateRange = (dateRange: DateRangeValue) => {
   const sortedRange = dateRange
@@ -18,4 +21,18 @@ export const validateDateRange = (dateRange: DateRangeValue) => {
       date: end,
     },
   }
+}
+
+export const pickRangeCalendarProps = (props: DateRangePickerProps) => {
+  return pick(
+    props,
+    'isCalendarFixedHeight',
+    'monthsToDisplay',
+    'isDateUnavailable',
+    'defaultFocusedDate',
+    'showTodayButton',
+    'shouldSetDateOnTodayButtonClick',
+    'onMonthChange',
+    'onYearChange',
+  )
 }


### PR DESCRIPTION
## Problem

`DatePicker` wasn't prop-drilling `onYearChange` and `onMonthChange` to the underlying `Calendar`

## Solution
- Standardise both `DatePicker` and `DateRangePicker` to drill with the `pick()` selector
- Add them 2 to the Calendar props
- Added stories on the parent `DatePicker` so we can assert this correct behaviour
