### PR TITLE
fix: disable tag delete button on readonly

### DIFF
--- a/packages/camp/src/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/camp/src/MultiSelect/MultiSelect.stories.tsx
@@ -183,3 +183,16 @@ export const FormInput: StoryFn<MultiSelectProps> = (args) => {
     </FormControl>
   )
 }
+
+export const ReadOnlyFormInput: StoryFn<MultiSelectProps> = () => {
+  return (
+    <FormControl isReadOnly id="test">
+      <MultiSelect
+        name="test"
+        values={['A', 'C', 'D']}
+        onChange={() => {}}
+        items={INITIAL_COMBOBOX_ITEMS}
+      />
+    </FormControl>
+  )
+}

--- a/packages/camp/src/MultiSelect/components/MultiSelectItem/MultiSelectItem.tsx
+++ b/packages/camp/src/MultiSelect/components/MultiSelectItem/MultiSelectItem.tsx
@@ -104,6 +104,7 @@ export const MultiSelectItem = ({
           aria-hidden
           as={itemMeta.icon}
           sx={styles.tagIcon}
+          aria-readonly={isReadOnly}
           aria-disabled={isDisabled}
         />
       ) : null}
@@ -111,7 +112,7 @@ export const MultiSelectItem = ({
       <TagCloseButton
         tabIndex={-1}
         aria-hidden
-        isDisabled={isDisabled}
+        isDisabled={isDisabled || isReadOnly}
         onClick={handleRemoveItem}
       />
     </Tag>

--- a/packages/camp/src/TagInput/TagInput.stories.tsx
+++ b/packages/camp/src/TagInput/TagInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@chakra-ui/react'
+import { FormControl, Stack } from '@chakra-ui/react'
 import { Meta, StoryFn } from '@storybook/react'
 
 import { getMobileViewParameters } from '~/utils/storybook'
@@ -56,6 +56,14 @@ Mobile.args = {
   ],
 }
 Mobile.parameters = getMobileViewParameters()
+
+export const ReadOnlyFormInput: StoryFn<TagInputProps> = (args) => {
+  return (
+    <FormControl isReadOnly id="test">
+      <TagInput defaultValue={['foo', 'bar']} {...args} />
+    </FormControl>
+  )
+}
 
 export const Sizes: StoryFn<TagInputProps> = (args) => {
   return (

--- a/packages/camp/src/TagInput/TagInput.tsx
+++ b/packages/camp/src/TagInput/TagInput.tsx
@@ -190,6 +190,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
           >
             {value.map((tag, index) => (
               <TagInputTag
+                isReadOnly={inputProps.readOnly}
                 isDisabled={inputProps.disabled}
                 key={index}
                 colorScheme={tagColorScheme}

--- a/packages/camp/src/TagInput/TagInput.tsx
+++ b/packages/camp/src/TagInput/TagInput.tsx
@@ -190,6 +190,7 @@ export const TagInput = forwardRef<TagInputProps, 'input'>(
           >
             {value.map((tag, index) => (
               <TagInputTag
+                sx={styles.tag}
                 isReadOnly={inputProps.readOnly}
                 isDisabled={inputProps.disabled}
                 key={index}

--- a/packages/camp/src/TagInput/TagInputTag.tsx
+++ b/packages/camp/src/TagInput/TagInputTag.tsx
@@ -10,6 +10,7 @@ import { Tag, TagCloseButton, TagLabel, TagProps } from '~/Tag'
 
 export interface TagInputTagProps extends TagProps {
   isDisabled?: boolean
+  isReadOnly?: boolean
   isInvalid?: boolean
   label: string
   onClearTag: (event: SyntheticEvent) => void
@@ -19,6 +20,7 @@ export interface TagInputTagProps extends TagProps {
 export const TagInputTag = ({
   label,
   isDisabled = false,
+  isReadOnly = false,
   isInvalid,
   colorScheme,
   onClearTag,
@@ -68,6 +70,7 @@ export const TagInputTag = ({
     <Tag
       cursor="pointer"
       aria-disabled={isDisabled}
+      aria-readonly={isReadOnly}
       aria-invalid={isInvalid}
       colorScheme={isInvalid ? 'critical' : colorScheme}
       {...props}
@@ -79,7 +82,7 @@ export const TagInputTag = ({
       <TagLabel title={label}>{label}</TagLabel>
       <TagCloseButton
         tabIndex={-1}
-        isDisabled={isDisabled}
+        isDisabled={isDisabled || isReadOnly}
         onClick={handleCloseButtonClick}
       />
     </Tag>

--- a/packages/camp/src/theme/components/TagInput.ts
+++ b/packages/camp/src/theme/components/TagInput.ts
@@ -4,7 +4,7 @@ import { anatomy } from '~/utils/anatomy'
 
 import { Input } from './Input'
 
-export const parts = anatomy('taginput').parts('container', 'field')
+export const parts = anatomy('taginput').parts('container', 'field', 'tag')
 
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)


### PR DESCRIPTION
## Problem

The delete buttons on tags within MultiSelect and TagInput components are not disabled when the field is readonly. This violates the readonly state of the field.

Also TagInput currently does not support overriding of Tag styles.

## Solution

Check if the field is readonly and disable the button.

Add a new Tag part style for TagInput.

Includes stories for testing.